### PR TITLE
Setting by default a tap event

### DIFF
--- a/SlidingUpPanel.js
+++ b/SlidingUpPanel.js
@@ -64,6 +64,7 @@ class SlidingUpPanel extends React.Component {
     this._renderBackdrop = this._renderBackdrop.bind(this)
     this._isInsideDraggableRange = this._isInsideDraggableRange.bind(this)
     this._triggerAnimation = this._triggerAnimation.bind(this)
+    this._isClosedAndIsATapEvent = this._isClosedAndIsATapEvent.bind(this)
 
     this.transitionTo = this.transitionTo.bind(this)
 
@@ -87,7 +88,8 @@ class SlidingUpPanel extends React.Component {
     this._flick = new FlickAnimation(this._translateYAnimation, -top, -bottom, this.props.onMomentumEnd, this.props.onBottomReached, this.props.onTopReached)
 
     this._panResponder = PanResponder.create({
-      onMoveShouldSetPanResponder: this._onMoveShouldSetPanResponder.bind(this),
+      onStartShouldSetPanResponderCapture: this._onStartShouldSetPanResponderCapture.bind(this),
+      onMoveShouldSetPanResponderCapture: this._onMoveShouldSetPanResponderCapture.bind(this),
       onPanResponderGrant: this._onPanResponderGrant.bind(this),
       onPanResponderMove: this._onPanResponderMove.bind(this),
       onPanResponderRelease: this._onPanResponderRelease.bind(this),
@@ -137,8 +139,13 @@ class SlidingUpPanel extends React.Component {
     }
   }
 
-  _onMoveShouldSetPanResponder(evt, gestureState) {
+  _onStartShouldSetPanResponderCapture(evt, gestureState) {
+    return false
+  }
+
+  _onMoveShouldSetPanResponderCapture(evt, gestureState) {
     return (
+      this._isClosedAndIsATapEvent(gestureState) &&
       this.props.allowDragging &&
       this._isInsideDraggableRange() &&
       Math.abs(gestureState.dy) > MINIMUM_DISTANCE_THRESHOLD
@@ -187,6 +194,14 @@ class SlidingUpPanel extends React.Component {
   // eslint-disable-next-line no-unused-vars
   _onPanResponderTerminate(evt, gestureState) {
     debugger;
+  }
+
+  _isClosedAndIsATapEvent(gestureState) {
+    if (this._isAtBottom && gestureState.dy >= -0.4 && gestureState.dy <= 0.4) {
+      return false
+    } else {
+      return true
+    }
   }
 
   _isInsideDraggableRange() {

--- a/SlidingUpPanel.js
+++ b/SlidingUpPanel.js
@@ -197,7 +197,7 @@ class SlidingUpPanel extends React.Component {
   }
 
   _isClosedAndIsATapEvent(gestureState) {
-    if (this._isAtBottom && gestureState.dy >= -0.4 && gestureState.dy <= 0.4) {
+    if (this._isAtBottom && gestureState.dy >= -1.5 && gestureState.dy <= 1.5) {
       return false
     } else {
       return true


### PR DESCRIPTION
When a user's finger es moved outside the interval (-0.4 && 0.4) the method `_onMoveShouldSetPanResponderCapture` should return true, allowing the normal slider's behavior.